### PR TITLE
Fix bugs from changing PhantomJS to Chrome.

### DIFF
--- a/nytdiff.py
+++ b/nytdiff.py
@@ -9,6 +9,8 @@ import os
 import sys
 import time
 
+from tempfile import NamedTemporaryFile
+
 import bleach
 import dataset
 from PIL import Image
@@ -204,11 +206,11 @@ class BaseParser(object):
           </body>
         </html>
         """.format(html_diff(old, new))
-        with open('tmp.html', 'w') as f:
+        with NamedTemporaryFile(mode='w', suffix=".html", delete=True) as f:
             f.write(html)
-
-        driver = webdriver.Chrome()
-        driver.get('file:///tmp.html')
+            f.flush()
+            driver = webdriver.Chrome()
+            driver.get('file://{}'.format(f.name))
         e = driver.find_element(By.XPATH, '//p')
         start_height = e.location['y']
         block_height = e.size['height']

--- a/nytdiff.py
+++ b/nytdiff.py
@@ -6,10 +6,11 @@ import hashlib
 import json
 import logging
 import os
+import shutil
 import sys
 import time
 
-from tempfile import NamedTemporaryFile
+from tempfile import TemporaryDirectory
 
 import bleach
 import dataset
@@ -197,7 +198,7 @@ class BaseParser(object):
         <html lang="en">
           <head>
             <meta charset="utf-8">
-            <link rel="stylesheet" href="./css/styles.css">
+            <link rel="stylesheet" href="styles.css">
           </head>
           <body>
           <p>
@@ -206,11 +207,14 @@ class BaseParser(object):
           </body>
         </html>
         """.format(html_diff(old, new))
-        with NamedTemporaryFile(mode='w', suffix=".html", delete=True) as f:
-            f.write(html)
-            f.flush()
+        with TemporaryDirectory() as tmpdir:
+            tmpfile = os.path.join(tmpdir, 'tmp.html')
+            with open(tmpfile, 'w') as f:
+                f.write(html)
+            shutil.copy('./css/styles.css', tmpdir)
             driver = webdriver.Chrome()
-            driver.get('file://{}'.format(f.name))
+            driver.get('file://{}'.format(tmpfile))
+
         e = driver.find_element(By.XPATH, '//p')
         start_height = e.location['y']
         block_height = e.size['height']


### PR DESCRIPTION
The Chrome WebDriver for Selenium appears to require a `file://` URL with a full pathname. This change uses NamedTemporaryFile to manage temporary file storage in a robust way, and supplies the proper pathname to the WebDriver client. The existing code (on macOS at least) will not find the generated HTML file at all.