### PR TITLE
Integrate upstream changes

### DIFF
--- a/nytdiff.py
+++ b/nytdiff.py
@@ -224,7 +224,7 @@ class BaseParser(object):
             )
         )
 
-    def bsky_post(self, text, article_data, column="id"):
+    def bsky_post(self, text, article_data, column="id", alt_text=""):
         if not self.bsky_api:
             return
         article_id = article_data["article_id"]
@@ -251,7 +251,7 @@ class BaseParser(object):
         post = self.bsky_api.send_image(
             text=text,
             image=img_data,
-            image_alt="",
+            image_alt=alt_text,
             reply_to=models.AppBskyFeedPost.ReplyRef(parent=parent_ref, root=root_ref),
         )
         child_ref = models.create_strong_ref(post)
@@ -446,7 +446,8 @@ class NYTParser(BaseParser):
                             old_text = row["url"].split("nytimes.com/")[1]
                             new_text = data["url"].split("nytimes.com/")[1]
                             alt_text = self.generate_alt_text(old_text, new_text)
-                            self.bsky_post(tweet_text, data, "article_id")
+                            self.bsky_post(
+                                tweet_text, data, "article_id", alt_text)
                             self.tweet(
                                 tweet_text,
                                 data["article_id"],
@@ -460,7 +461,8 @@ class NYTParser(BaseParser):
                             alt_text = self.generate_alt_text(
                                 row["title"], data["title"]
                             )
-                            self.bsky_post(tweet_text, data, "article_id")
+                            self.bsky_post(
+                                tweet_text, data, "article_id", alt_text)
                             self.tweet(
                                 tweet_text,
                                 data["article_id"],
@@ -474,7 +476,8 @@ class NYTParser(BaseParser):
                             alt_text = self.generate_alt_text(
                                 row["abstract"], data["abstract"]
                             )
-                            self.bsky_post(tweet_text, data, "article_id")
+                            self.bsky_post(
+                                tweet_text, data, "article_id", alt_text)
                             self.tweet(
                                 tweet_text,
                                 data["article_id"],
@@ -488,7 +491,8 @@ class NYTParser(BaseParser):
                             alt_text = self.generate_alt_text(
                                 row["kicker"], data["kicker"]
                             )
-                            self.bsky_post(tweet_text, data, "article_id")
+                            self.bsky_post(
+                                tweet_text, data, "article_id", alt_text)
                             self.tweet(
                                 tweet_text,
                                 data["article_id"],

--- a/nytdiff.py
+++ b/nytdiff.py
@@ -320,7 +320,6 @@ class BaseParser(object):
                 shutil.copytree(d, os.path.join(tmpdir, d))
             opts = webdriver.chrome.options.Options()
             opts.add_argument("--headless")
-            opts.add_argument("--window-size=400,400")
             driver = webdriver.Chrome(options=opts)
             driver.get("file://{}".format(tmpfile))
             logging.info("tmpfile is %s", tmpfile)


### PR DESCRIPTION
Needed to make these changes to make the master branch work on Bluesky:

* Made it optional to supply either Twitter or Bluesky credentials (if creds are not supplied, simply skip posting to that service)
* `bleach.clean` no longer takes a `styles` argument
* json_to_dict now canonically makes the `uri` property the `article_id`, so I think the extra logic to select an article_id is no longer necessary -- please check me on that assumption

And some changes that weren't necessary but were quick or already on my branch:
* Improved website card thumbnail handling on Bluesky (we were defaulting to 150px images)
* Added alt-text support
* Fixed cropping of diff images