### PR TITLE
Added aspect ratio hints for Bluesky image embeds.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 alembic>=1.13.1,<2.0.0
-atproto>=0.0.44,<1.0.0
+atproto>=0.0.50,<1.0.0
 bleach>=6.1.0,<7.0.0
 dataset>=1.6.2,<2.0.0
 html5lib>=1.1,<2.0
@@ -7,6 +7,7 @@ Mako>=1.3.2,<2.0.0
 MarkupSafe>=2.1.5,<3.0.0
 normality>=2.5.0,<3.0.0
 oauthlib>=3.2.2,<4.0.0
+pillow>=11.0
 python-editor>=1.0.4,<2.0.0
 pytz>=2024.1,<2025.0
 PyYAML>=6.0.1,<7.0.0


### PR DESCRIPTION
Bluesky recently added an `aspectRatio` parameter for posting image embeds. Images posted without an aspectRatiio hint are rendered full size and cropped arbitrarily, which makes the image thumbnail preview illegible. This change adds the aspectRatio for each thumbnail issue upon upload.